### PR TITLE
Add vercel config for client-side routing

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,10 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "cleanUrls": true,
+  "trailingSlash": false
+}


### PR DESCRIPTION
Added vercel.json to support single-page application routing. This prevents 404 errors on deep links like /admin/login by redirecting all routes to index.html. Necessary for Vercel deployments using React Router with Vite.