### PR TITLE
Trust proxy to fix rate limit error

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -5,6 +5,8 @@ const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
+app.set('trust proxy', 1);
+
 // Initialize Express app
 const app = express();
 const PORT = process.env.PORT || 5050;


### PR DESCRIPTION
Enable Express to trust the Render proxy by setting 'trust proxy' to 1. This resolves the 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR' error thrown by express-rate-limit when detecting proxy headers.