### PR TITLE
Fix admin route handling for Vercel deploy

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/index.html"
+      "destination": "/"
     }
   ],
   "cleanUrls": true,


### PR DESCRIPTION
Update vercel.json rewrite destination to "/"
instead of "/index.html" to support SPA routing
with Vite and react-router. Prevents 404 errors
on direct admin page navigation.