### PR TITLE
Pages/teaching

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,26 @@
 // src/App.tsx
+import { useLocation } from 'react-router-dom';
 import { AppRoutes } from "./router";
 import Navbar from "./components/navbar/Navbar.tsx";
 
 function App() {
+  const location = useLocation();
+  
+  // Define routes where navbar should be hidden
+  const hideNavbarRoutes = [
+    '/teaching',
+    '/teaching/csci133/unit1',
+    // Add more stuff here routes as needed
+  ];
+  
+  const shouldHideNavbar = hideNavbarRoutes.some(route => 
+    location.pathname === route || location.pathname.startsWith(route + '/')
+  );
+
   return (
     <>
-      <Navbar />
-      <main className="pt-20">
+      {!shouldHideNavbar && <Navbar />}
+      <main className={shouldHideNavbar ? "" : "pt-20"}>
         <AppRoutes />
       </main>
     </>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -36,10 +36,12 @@
     margin: 0;
     min-height: 100vh;
     background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%);
+    overscroll-behavior-y: none;
   }
 
   html {
     scroll-behavior: smooth;
+    overscroll-behavior: none;
   }
 }
 

--- a/client/src/pages/teaching/CoursesHome.module.css
+++ b/client/src/pages/teaching/CoursesHome.module.css
@@ -1,0 +1,602 @@
+.container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* Header Section */
+.header {
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 4rem 0 3rem;
+}
+
+.headerContent {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+  text-align: center;
+}
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.title {
+  font-size: 3.5rem;
+  font-weight: 700;
+  margin: 0;
+  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  font-size: 1.25rem;
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.6;
+  margin: 0;
+  max-width: 48rem;
+  margin: 0 auto;
+}
+
+/* Main Content */
+.main {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 3rem 2rem 4rem;
+}
+
+.coursesSection {
+  margin-bottom: 2rem;
+}
+
+.sectionHeader {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.sectionTitle {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.sectionDescription {
+  font-size: 1.125rem;
+  color: rgba(255, 255, 255, 0.7);
+  max-width: 32rem;
+  margin: 0 auto;
+}
+
+/* Courses Grid */
+.coursesGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.courseCard {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.courseCard:hover {
+  border-color: rgba(96, 165, 250, 0.3);
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.courseHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.courseHeader:hover {
+  background: rgba(51, 65, 85, 0.3);
+}
+
+.courseHeader::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: linear-gradient(135deg, var(--course-primary), var(--course-secondary));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.courseCard:hover .courseHeader::before {
+  opacity: 1;
+}
+
+.courseHeaderContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.courseTitle {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.courseCode {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--course-primary, rgba(96, 165, 250, 0.9));
+  background: rgba(96, 165, 250, 0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(96, 165, 250, 0.2);
+}
+
+.courseName {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.courseMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.studentCount {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.studentIcon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.courseDescription {
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.6;
+  margin: 0;
+  font-size: 1rem;
+}
+
+.expandIcon {
+  margin-left: 2rem;
+}
+
+.chevron {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: rgba(255, 255, 255, 0.4);
+  transition: all 0.3s ease;
+}
+
+.courseCard:hover .chevron {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* Units Container */
+.unitsContainer {
+  background: rgba(15, 23, 42, 0.6);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+}
+
+.unitsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.unitsTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin: 0;
+}
+
+.unitsList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.unitCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(51, 65, 85, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.unitCard:hover {
+  background: rgba(51, 65, 85, 0.6);
+  border-color: rgba(96, 165, 250, 0.3);
+}
+
+.unitContent {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+}
+
+.unitNumber {
+  width: 2.5rem;
+  height: 2.5rem;
+  background: linear-gradient(135deg, #374151, #4b5563);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.unitInfo {
+  flex: 1;
+}
+
+.unitHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.unitTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin: 0;
+}
+
+.unitDescription {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.unitActions {
+  margin-left: 2rem;
+  flex-shrink: 0;
+}
+
+.unitLink {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, var(--course-primary), var(--course-secondary));
+  color: white;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: all 0.3s ease;
+}
+
+.unitLink:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+}
+
+.linkIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+  .main {
+    padding: 3rem 1.5rem 4rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .container {
+    padding: 1rem 0;
+  }
+
+  .header {
+    padding: 3rem 0 2.5rem;
+  }
+
+  .headerContent {
+    padding: 0 1.5rem;
+  }
+  
+  .title {
+    font-size: 3rem;
+  }
+  
+  .main {
+    padding: 2rem 1.5rem 3rem;
+  }
+
+  .sectionTitle {
+    font-size: 2.25rem;
+  }
+
+  .courseHeader {
+    padding: 1.75rem;
+  }
+
+  .unitsContainer {
+    padding: 1.75rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  }
+
+  .header {
+    padding: 2rem 0 2rem;
+  }
+
+  .headerContent {
+    padding: 0 1rem;
+  }
+  
+  .title {
+    font-size: 2.5rem;
+    line-height: 1.1;
+  }
+  
+  .subtitle {
+    font-size: 1.125rem;
+    line-height: 1.5;
+  }
+  
+  .sectionTitle {
+    font-size: 2rem;
+  }
+
+  .sectionDescription {
+    font-size: 1rem;
+  }
+  
+  .courseCard {
+    border-radius: 1rem;
+  }
+
+  .courseHeader {
+    padding: 1.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .courseHeaderContent {
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+  
+  .courseTitle {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .courseCode {
+    font-size: 1.125rem;
+    padding: 0.5rem 0.875rem;
+  }
+  
+  .courseName {
+    font-size: 1.375rem;
+    line-height: 1.3;
+  }
+  
+  .courseMeta {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+  }
+
+  .courseDescription {
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  .expandIcon {
+    margin-left: 0;
+    align-self: center;
+  }
+  
+  .unitsContainer {
+    padding: 1.5rem;
+  }
+  
+  .unitsHeader {
+    margin-bottom: 1.25rem;
+  }
+
+  .unitsTitle {
+    font-size: 1.125rem;
+  }
+  
+  .unitCard {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1.25rem;
+  }
+  
+  .unitContent {
+    width: 100%;
+  }
+
+  .unitNumber {
+    width: 2rem;
+    height: 2rem;
+    font-size: 0.875rem;
+  }
+
+  .unitTitle {
+    font-size: 1rem;
+  }
+
+  .unitDescription {
+    font-size: 0.8125rem;
+  }
+  
+  .unitActions {
+    margin-left: 0;
+    align-self: stretch;
+  }
+  
+  .unitLink {
+    width: 100%;
+    justify-content: center;
+    padding: 0.875rem 1.25rem;
+  }
+
+  .main {
+    padding: 2rem 1rem 3rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .header {
+    padding: 1.5rem 0 1.5rem;
+  }
+
+  .headerContent {
+    padding: 0 1rem;
+  }
+
+  .title {
+    font-size: 2rem;
+    line-height: 1.1;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.75rem;
+  }
+
+  .courseHeader {
+    padding: 1.25rem;
+  }
+  
+  .courseCode {
+    font-size: 1rem;
+    padding: 0.4375rem 0.75rem;
+  }
+  
+  .courseName {
+    font-size: 1.25rem;
+  }
+
+  .courseDescription {
+    font-size: 0.875rem;
+  }
+
+  .courseMeta {
+    font-size: 0.75rem;
+    gap: 0.375rem;
+  }
+
+  .unitsContainer {
+    padding: 1.25rem;
+  }
+
+  .unitCard {
+    padding: 1rem;
+  }
+
+  .unitNumber {
+    width: 1.75rem;
+    height: 1.75rem;
+    font-size: 0.8125rem;
+  }
+
+  .unitTitle {
+    font-size: 0.9375rem;
+  }
+
+  .unitDescription {
+    font-size: 0.75rem;
+  }
+
+  .unitLink {
+    padding: 0.75rem 1rem;
+    font-size: 0.8125rem;
+  }
+
+  .linkIcon {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+  
+  .main {
+    padding: 1.5rem 1rem 2rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .title {
+    font-size: 1.75rem;
+  }
+
+  .courseHeader {
+    padding: 1rem;
+  }
+
+  .unitsContainer {
+    padding: 1rem;
+  }
+
+  .unitCard {
+    padding: 0.875rem;
+  }
+
+  .main {
+    padding: 1.25rem 0.875rem 1.5rem;
+  }
+}

--- a/client/src/pages/teaching/CoursesHome.tsx
+++ b/client/src/pages/teaching/CoursesHome.tsx
@@ -1,0 +1,180 @@
+// src/pages/courses/CoursesHome.tsx
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronDown, ChevronRight, Users, ExternalLink } from 'lucide-react';
+import styles from './CoursesHome.module.css';
+
+interface Unit {
+  id: string;
+  title: string;
+  description: string;
+  path: string;
+  status: 'available';
+}
+
+interface Course {
+  id: string;
+  code: string;
+  title: string;
+  description: string;
+  semester: string;
+  year: string;
+  institution: string;
+  totalStudents?: number;
+  units: Unit[];
+  color: {
+    primary: string;
+    secondary: string;
+  };
+}
+
+const CoursesHome: React.FC = () => {
+  const [expandedCourses, setExpandedCourses] = useState<Record<string, boolean>>({});
+
+  const toggleCourse = (courseId: string) => {
+    setExpandedCourses(prev => ({
+      ...prev,
+      [courseId]: !prev[courseId]
+    }));
+  };
+
+  const courses: Course[] = [
+    {
+      id: 'csci133',
+      code: 'CSCI 133',
+      title: 'Computer Programming',
+      description: 'Introduction to computer programming using Python. Covers fundamental programming concepts including variables, control structures, functions, and basic data structures.',
+      semester: 'Fall',
+      year: '2025',
+      institution: 'Hunter College',
+      totalStudents: 45,
+      color: {
+        primary: '#60a5fa',
+        secondary: '#3b82f6'
+      },
+      units: [
+        {
+          id: 'unit1',
+          title: 'Unit 1: Python Fundamentals',
+          description: 'Getting started with Python, variables, strings, lists, and basic control structures',
+          path: '/teaching/csci133/unit1',
+          status: 'available'
+        }
+        // Only include available units - add more as you create them
+      ]
+    }
+    // Add more courses as needed
+  ];
+
+  return (
+    <div className={styles.container}>
+      {/* Header */}
+      <div className={styles.header}>
+        <div className={styles.headerContent}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>Teaching</h1>
+            <p className={styles.subtitle}>
+              Course materials, resources, and interactive content for my students at Hunter College
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className={styles.main}>
+        <div className={styles.coursesSection}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>Current Courses</h2>
+            <p className={styles.sectionDescription}>
+              Click on any course to explore available units and materials
+            </p>
+          </div>
+
+          <div className={styles.coursesGrid}>
+            {courses.map((course) => (
+              <div key={course.id} className={styles.courseCard}>
+                {/* Course Header */}
+                <button
+                  onClick={() => toggleCourse(course.id)}
+                  className={styles.courseHeader}
+                  style={{
+                    '--course-primary': course.color.primary,
+                    '--course-secondary': course.color.secondary
+                  } as React.CSSProperties}
+                >
+                  <div className={styles.courseHeaderContent}>
+                    <div className={styles.courseTitle}>
+                      <span className={styles.courseCode}>{course.code}</span>
+                      <span className={styles.courseName}>{course.title}</span>
+                    </div>
+                    <div className={styles.courseMeta}>
+                      <span>{course.semester} {course.year}</span>
+                      <span>•</span>
+                      <span>{course.institution}</span>
+                      {course.totalStudents && (
+                        <>
+                          <span>•</span>
+                          <span className={styles.studentCount}>
+                            <Users className={styles.studentIcon} />
+                            {course.totalStudents} students
+                          </span>
+                        </>
+                      )}
+                    </div>
+                    <p className={styles.courseDescription}>{course.description}</p>
+                  </div>
+                  <div className={styles.expandIcon}>
+                    {expandedCourses[course.id] ? (
+                      <ChevronDown className={styles.chevron} />
+                    ) : (
+                      <ChevronRight className={styles.chevron} />
+                    )}
+                  </div>
+                </button>
+
+                {/* Units Dropdown */}
+                {expandedCourses[course.id] && (
+                  <div className={styles.unitsContainer}>
+                    <div className={styles.unitsHeader}>
+                      <h3 className={styles.unitsTitle}>Available Units</h3>
+                    </div>
+                    
+                    <div className={styles.unitsList}>
+                      {course.units.map((unit, index) => (
+                        <div key={unit.id} className={styles.unitCard}>
+                          <div className={styles.unitContent}>
+                            <div className={styles.unitNumber}>{index + 1}</div>
+                            <div className={styles.unitInfo}>
+                              <div className={styles.unitHeader}>
+                                <h4 className={styles.unitTitle}>{unit.title}</h4>
+                              </div>
+                              <p className={styles.unitDescription}>{unit.description}</p>
+                            </div>
+                          </div>
+                          <div className={styles.unitActions}>
+                            <Link 
+                              to={unit.path} 
+                              className={styles.unitLink}
+                              style={{
+                                '--course-primary': course.color.primary
+                              } as React.CSSProperties}
+                            >
+                              <span>View Unit</span>
+                              <ExternalLink className={styles.linkIcon} />
+                            </Link>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CoursesHome;

--- a/client/src/pages/teaching/csci133/unit1/CSCI133Unit1.module.css
+++ b/client/src/pages/teaching/csci133/unit1/CSCI133Unit1.module.css
@@ -1,0 +1,1232 @@
+.container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* Header Section */
+.header {
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 4rem 0 3rem;
+}
+
+.headerContent {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+  text-align: center;
+}
+
+.title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  font-size: 1.5rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 2rem;
+  font-weight: 300;
+}
+
+.courseMeta {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.875rem;
+  font-weight: 400;
+}
+
+/* Navigation */
+.navigation {
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.navContent {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.navTabs {
+  display: flex;
+  gap: 2rem;
+}
+
+.navTab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.navTab:hover {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navTabActive {
+  color: rgba(96, 165, 250, 0.9);
+  border-bottom-color: rgba(96, 165, 250, 0.7);
+}
+
+.navTabIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Main Content */
+.main {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 3rem 2rem 4rem;
+}
+
+.tabContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Overview Tab */
+.overviewSection {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  padding: 2rem;
+}
+
+.sectionTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.sectionDescription {
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  font-size: 1.125rem;
+}
+
+.overviewGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr));
+  gap: 2rem;
+}
+
+.objectivesCard,
+.prerequisitesCard {
+  background: rgba(96, 165, 250, 0.05);
+  border: 1px solid rgba(96, 165, 250, 0.2);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+}
+
+.cardTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(96, 165, 250, 0.9);
+  margin-bottom: 1rem;
+}
+
+.objectivesList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.objectivesList li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: rgba(255, 255, 255, 0.8);
+  line-height: 1.5;
+}
+
+.objectivesList li:before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  background: rgba(96, 165, 250, 0.7);
+  border-radius: 50%;
+}
+
+/* Progress Section */
+.progressSection {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  padding: 2rem;
+}
+
+.progressGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.progressItem {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: rgba(51, 65, 85, 0.4);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all 0.3s ease;
+}
+
+.progressItem:hover {
+  background: rgba(51, 65, 85, 0.6);
+  transform: translateY(-2px);
+}
+
+.progressNumber {
+  width: 2rem;
+  height: 2rem;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.progressContent {
+  flex: 1;
+}
+
+.progressTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 0.25rem;
+}
+
+.progressDescription {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0;
+}
+
+/* Lessons Tab */
+.lessonsGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.lessonCard {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.lessonCard:hover {
+  border-color: rgba(96, 165, 250, 0.3);
+  transform: translateY(-2px);
+}
+
+.lessonHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.3s ease;
+}
+
+.lessonHeader:hover {
+  background: rgba(51, 65, 85, 0.3);
+}
+
+.lessonHeaderContent {
+  flex: 1;
+}
+
+.lessonTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 0.5rem;
+}
+
+.lessonDescription {
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0;
+}
+
+.chevron {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: rgba(255, 255, 255, 0.4);
+  transition: transform 0.3s ease;
+}
+
+.lessonBody {
+  padding: 0 1.5rem 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+/* Lesson Content Styles */
+.lessonContent {
+  padding-top: 1rem;
+}
+
+.lessonContent p {
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.conceptBox {
+  background: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.conceptTitle {
+  color: rgba(96, 165, 250, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.conceptList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.conceptList li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: rgba(96, 165, 250, 0.8);
+  line-height: 1.5;
+}
+
+.conceptList li:before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  width: 0.375rem;
+  height: 0.375rem;
+  background: rgba(96, 165, 250, 0.7);
+  border-radius: 50%;
+}
+
+.warningBox {
+  background: rgba(251, 191, 36, 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.warningTitle {
+  color: rgba(251, 191, 36, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.warningBox p {
+  color: rgba(251, 191, 36, 0.8);
+  margin: 0;
+}
+
+.infoBox {
+  background: rgba(167, 139, 250, 0.1);
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.infoTitle {
+  color: rgba(167, 139, 250, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.infoBox p {
+  color: rgba(167, 139, 250, 0.8);
+  margin: 0;
+}
+
+.tipBox {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.tipTitle {
+  color: rgba(34, 197, 94, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.tipBox p {
+  color: rgba(34, 197, 94, 0.8);
+  margin: 0;
+}
+
+.codeExample {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.codeTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+}
+
+.codeIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.codeBlock {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  overflow-x: auto;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.codeBlock code {
+  color: rgba(34, 197, 94, 0.9);
+  background: none;
+  padding: 0;
+}
+
+.codeBlockSmall {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  overflow-x: auto;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.codeBlockSmall code {
+  color: rgba(34, 197, 94, 0.9);
+  background: none;
+  padding: 0;
+}
+
+.codeNote {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.875rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+}
+
+.inlineCode {
+  background: rgba(96, 165, 250, 0.1);
+  color: rgba(96, 165, 250, 0.9);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.875rem;
+}
+
+.comparisonBox {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.comparisonTitle {
+  color: rgba(239, 68, 68, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.comparisonBox p {
+  color: rgba(239, 68, 68, 0.8);
+  margin-bottom: 1rem;
+}
+
+.comparisonGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  gap: 1rem;
+}
+
+.goodExample,
+.badExample {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.exampleLabel {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.goodExample .exampleLabel {
+  color: rgba(34, 197, 94, 0.9);
+}
+
+.badExample .exampleLabel {
+  color: rgba(239, 68, 68, 0.9);
+}
+
+/* Practice Tab */
+.practiceIntro {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+.exercisesGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.exerciseCard {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.exerciseCard:hover {
+  border-color: rgba(96, 165, 250, 0.3);
+  transform: translateY(-2px);
+}
+
+.exerciseHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.3s ease;
+}
+
+.exerciseHeader:hover {
+  background: rgba(51, 65, 85, 0.3);
+}
+
+.exerciseHeaderContent {
+  flex: 1;
+}
+
+.exerciseTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 0.5rem;
+}
+
+.exerciseDescription {
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0;
+}
+
+.exerciseBody {
+  padding: 0 1.5rem 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.exerciseContent {
+  padding-top: 1rem;
+}
+
+.starterSection {
+  margin-bottom: 1.5rem;
+}
+
+.starterTitle {
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.solutionDetails {
+  background: rgba(51, 65, 85, 0.4);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.solutionSummary {
+  color: rgba(96, 165, 250, 0.9);
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+
+.solutionSummary:hover {
+  color: rgba(96, 165, 250, 1);
+}
+
+.solutionContent {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.helpSection {
+  background: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+  border-radius: 1rem;
+  padding: 2rem;
+}
+
+.helpTitle {
+  color: rgba(96, 165, 250, 0.9);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+}
+
+.helpDescription {
+  color: rgba(96, 165, 250, 0.8);
+  margin-bottom: 1rem;
+}
+
+.helpList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.helpList li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: rgba(96, 165, 250, 0.8);
+  line-height: 1.5;
+  font-size: 0.875rem;
+}
+
+.helpList li:before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  width: 0.375rem;
+  height: 0.375rem;
+  background: rgba(96, 165, 250, 0.7);
+  border-radius: 50%;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+  .main {
+    padding: 3rem 1.5rem 4rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .container {
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  }
+
+  .header {
+    padding: 3rem 0 2.5rem;
+  }
+
+  .headerContent {
+    padding: 0 1.5rem;
+  }
+
+  .title {
+    font-size: 2.5rem;
+  }
+  
+  .subtitle {
+    font-size: 1.25rem;
+  }
+  
+  .overviewGrid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .comparisonGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .main {
+    padding: 2rem 1.5rem 3rem;
+  }
+
+  .overviewSection,
+  .practiceIntro,
+  .helpSection {
+    padding: 1.75rem;
+  }
+
+  .lessonHeader,
+  .exerciseHeader {
+    padding: 1.25rem;
+  }
+
+  .lessonBody,
+  .exerciseBody {
+    padding: 0 1.25rem 1.25rem;
+  }
+
+  .codeExample {
+    padding: 1.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    min-height: auto;
+  }
+
+  .header {
+    padding: 2rem 0 2rem;
+  }
+
+  .headerContent {
+    padding: 0 1rem;
+    text-align: center;
+  }
+  
+  .title {
+    font-size: 2rem;
+    line-height: 1.1;
+    margin-bottom: 0.75rem;
+  }
+  
+  .subtitle {
+    font-size: 1.125rem;
+    line-height: 1.4;
+    margin-bottom: 1.5rem;
+  }
+  
+  .courseMeta {
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+  }
+  
+  .courseMeta span:not(:last-child):after {
+    content: none;
+  }
+  
+  .navTabs {
+    gap: 1rem;
+    justify-content: center;
+  }
+  
+  .navTab {
+    font-size: 0.875rem;
+    padding: 0.875rem 0;
+    flex: 1;
+    justify-content: center;
+  }
+
+  .navTabIcon {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+  
+  .main {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.75rem;
+  }
+
+  .sectionDescription {
+    font-size: 1rem;
+  }
+  
+  .overviewSection,
+  .practiceIntro,
+  .helpSection {
+    padding: 1.5rem;
+  }
+
+  .overviewGrid {
+    gap: 1.5rem;
+  }
+
+  .objectivesCard,
+  .prerequisitesCard {
+    padding: 1.25rem;
+  }
+
+  .cardTitle {
+    font-size: 1.125rem;
+  }
+  
+  .progressItem {
+    padding: 0.875rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .progressNumber {
+    width: 1.75rem;
+    height: 1.75rem;
+    font-size: 0.8125rem;
+  }
+
+  .progressTitle {
+    font-size: 0.9375rem;
+  }
+
+  .progressDescription {
+    font-size: 0.8125rem;
+  }
+  
+  .lessonCard,
+  .exerciseCard {
+    border-radius: 0.875rem;
+  }
+
+  .lessonHeader,
+  .exerciseHeader {
+    padding: 1rem;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .lessonHeaderContent,
+  .exerciseHeaderContent {
+    width: 100%;
+    margin-bottom: 0.75rem;
+  }
+
+  .lessonTitle,
+  .exerciseTitle {
+    font-size: 1.125rem;
+    line-height: 1.3;
+  }
+
+  .lessonDescription,
+  .exerciseDescription {
+    font-size: 0.875rem;
+  }
+
+  .chevron {
+    width: 1.125rem;
+    height: 1.125rem;
+    align-self: center;
+  }
+  
+  .lessonBody,
+  .exerciseBody {
+    padding: 0 1rem 1rem;
+  }
+
+  .lessonContent {
+    padding-top: 0.75rem;
+  }
+
+  .lessonContent p {
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  .conceptBox,
+  .warningBox,
+  .infoBox,
+  .tipBox,
+  .comparisonBox {
+    padding: 1.25rem;
+    margin: 1.25rem 0;
+  }
+
+  .conceptTitle,
+  .warningTitle,
+  .infoTitle,
+  .tipTitle,
+  .comparisonTitle {
+    font-size: 0.9375rem;
+  }
+
+  .codeExample {
+    padding: 1rem;
+    margin: 1.25rem 0;
+  }
+
+  .codeTitle {
+    font-size: 0.9375rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .codeIcon {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+  
+  .codeBlock,
+  .codeBlockSmall {
+    font-size: 0.75rem;
+    line-height: 1.4;
+    padding: 0.75rem;
+  }
+
+  .codeNote {
+    font-size: 0.8125rem;
+    margin-top: 0.5rem;
+  }
+
+  .inlineCode {
+    font-size: 0.8125rem;
+    padding: 0.125rem 0.3125rem;
+  }
+
+  .exerciseContent {
+    padding-top: 0.75rem;
+  }
+
+  .starterTitle {
+    font-size: 0.9375rem;
+  }
+
+  .solutionDetails {
+    padding: 0.875rem;
+  }
+
+  .solutionSummary {
+    font-size: 0.9375rem;
+  }
+
+  .helpTitle {
+    font-size: 1.125rem;
+  }
+
+  .helpDescription {
+    font-size: 0.9375rem;
+  }
+
+  .helpList li {
+    font-size: 0.8125rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .header {
+    padding: 1.5rem 0 1.5rem;
+  }
+
+  .headerContent {
+    padding: 0 1rem;
+  }
+
+  .title {
+    font-size: 1.75rem;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+  }
+
+  .courseMeta {
+    font-size: 0.75rem;
+  }
+  
+  .navTabs {
+    justify-content: space-around;
+    gap: 0.5rem;
+  }
+  
+  .navTab {
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    padding: 0.75rem 0;
+  }
+  
+  .navTabIcon {
+    width: 0.8125rem;
+    height: 0.8125rem;
+  }
+
+  .main {
+    padding: 1.25rem 0.875rem 1.5rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.5rem;
+  }
+
+  .sectionDescription {
+    font-size: 0.9375rem;
+  }
+
+  .overviewSection,
+  .practiceIntro,
+  .helpSection {
+    padding: 1.25rem;
+  }
+
+  .objectivesCard,
+  .prerequisitesCard {
+    padding: 1rem;
+  }
+
+  .cardTitle {
+    font-size: 1rem;
+  }
+
+  .objectivesList li {
+    font-size: 0.875rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .progressItem {
+    padding: 0.75rem;
+  }
+
+  .progressNumber {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 0.75rem;
+  }
+
+  .progressTitle {
+    font-size: 0.875rem;
+  }
+
+  .progressDescription {
+    font-size: 0.75rem;
+  }
+
+  .lessonHeader,
+  .exerciseHeader {
+    padding: 0.875rem;
+  }
+
+  .lessonTitle,
+  .exerciseTitle {
+    font-size: 1rem;
+  }
+
+  .lessonDescription,
+  .exerciseDescription {
+    font-size: 0.8125rem;
+  }
+
+  .lessonBody,
+  .exerciseBody {
+    padding: 0 0.875rem 0.875rem;
+  }
+
+  .lessonContent p {
+    font-size: 0.875rem;
+  }
+
+  .conceptBox,
+  .warningBox,
+  .infoBox,
+  .tipBox,
+  .comparisonBox {
+    padding: 1rem;
+    margin: 1rem 0;
+  }
+
+  .conceptTitle,
+  .warningTitle,
+  .infoTitle,
+  .tipTitle,
+  .comparisonTitle {
+    font-size: 0.875rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .conceptList li,
+  .helpList li {
+    font-size: 0.75rem;
+    padding-left: 1.25rem;
+  }
+
+  .conceptList li:before,
+  .helpList li:before {
+    top: 0.4375rem;
+    width: 0.3125rem;
+    height: 0.3125rem;
+  }
+
+  .codeExample {
+    padding: 0.875rem;
+  }
+
+  .codeTitle {
+    font-size: 0.875rem;
+  }
+
+  .codeIcon {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  .codeBlock,
+  .codeBlockSmall {
+    font-size: 0.6875rem;
+    padding: 0.625rem;
+  }
+
+  .codeNote {
+    font-size: 0.75rem;
+  }
+
+  .inlineCode {
+    font-size: 0.75rem;
+  }
+
+  .comparisonGrid {
+    gap: 0.75rem;
+  }
+
+  .goodExample,
+  .badExample {
+    padding: 0.75rem;
+  }
+
+  .exampleLabel {
+    font-size: 0.8125rem;
+  }
+
+  .starterTitle {
+    font-size: 0.875rem;
+  }
+
+  .solutionDetails {
+    padding: 0.75rem;
+  }
+
+  .solutionSummary {
+    font-size: 0.875rem;
+  }
+
+  .helpTitle {
+    font-size: 1rem;
+  }
+
+  .helpDescription {
+    font-size: 0.875rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .title {
+    font-size: 1.5rem;
+  }
+
+  .main {
+    padding: 1rem 0.75rem 1.25rem;
+  }
+
+  .overviewSection,
+  .practiceIntro,
+  .helpSection {
+    padding: 1rem;
+  }
+
+  .lessonHeader,
+  .exerciseHeader {
+    padding: 0.75rem;
+  }
+
+  .lessonBody,
+  .exerciseBody {
+    padding: 0 0.75rem 0.75rem;
+  }
+
+  .codeExample {
+    padding: 0.75rem;
+  }
+
+  .conceptBox,
+  .warningBox,
+  .infoBox,
+  .tipBox,
+  .comparisonBox {
+    padding: 0.875rem;
+  }
+}

--- a/client/src/pages/teaching/csci133/unit1/CSCI133Unit1.tsx
+++ b/client/src/pages/teaching/csci133/unit1/CSCI133Unit1.tsx
@@ -1,0 +1,634 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronRight, Play, Code, BookOpen, Terminal } from 'lucide-react';
+import styles from './CSCI133Unit1.module.css';
+
+interface Lesson {
+  id: string;
+  title: string;
+  description: string;
+  content: React.ReactElement;
+}
+
+interface Exercise {
+  title: string;
+  description: string;
+  starter: string;
+  solution: string;
+}
+
+const CSCI133Unit1: React.FC = () => {
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
+  const [activeTab, setActiveTab] = useState<'overview' | 'lessons' | 'practice'>('overview');
+
+  const toggleSection = (section: string) => {
+    setExpandedSections(prev => ({
+      ...prev,
+      [section]: !prev[section]
+    }));
+  };
+
+  const lessons: Lesson[] = [
+    {
+      id: 'part1',
+      title: 'Part 1: Getting Started with Python',
+      description: 'Setting up IDLE and running your first Python program',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            In this first lesson, you'll learn how to set up the Python IDLE environment and run your very first Python program.
+          </p>
+          
+          <div className={styles.conceptBox}>
+            <h4 className={styles.conceptTitle}>Key Concepts:</h4>
+            <ul className={styles.conceptList}>
+              <li>Starting IDLE (Python Shell)</li>
+              <li>Understanding the interpreter window vs program file window</li>
+              <li>Creating and saving Python files (.py extension)</li>
+              <li>Running programs with F5</li>
+            </ul>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>
+              <Code className={styles.codeIcon} />
+              Your First Program
+            </h4>
+            <pre className={styles.codeBlock}>
+              <code>{`print(5)
+print(6)`}</code>
+            </pre>
+            <p className={styles.codeNote}>
+              Save this as a .py file and run it with F5 to see your first Python output!
+            </p>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part2',
+      title: 'Part 2: Using the Python Interpreter',
+      description: 'Interactive programming with the Python shell',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            Learn how to use Python's interactive interpreter for quick experiments and calculations.
+          </p>
+          
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>
+              <Terminal className={styles.codeIcon} />
+              Interactive Example
+            </h4>
+            <pre className={styles.codeBlock}>
+              <code>{`>>> print(5)
+5
+>>>`}</code>
+            </pre>
+            <p className={styles.codeNote}>
+              The {'>>>'} prompt indicates where you can type Python commands directly.
+            </p>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part3',
+      title: 'Part 3: Variables and Strings',
+      description: 'Creating variables and working with text',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            Variables allow us to store and reuse data. In Python, we use the equals sign (=) to assign values to variable names.
+          </p>
+
+          <div className={styles.warningBox}>
+            <h4 className={styles.warningTitle}>Important Note:</h4>
+            <p>
+              The equals sign (=) in Python is <strong>assignment</strong>, not mathematical equality. 
+              Read "student = 'Fred'" as "student refers to the string Fred."
+            </p>
+          </div>
+          
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Example: Creating Variables</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`student = 'Fred'
+print('Hello', student)
+
+# Output: Hello Fred`}</code>
+            </pre>
+          </div>
+
+          <div className={styles.comparisonBox}>
+            <h4 className={styles.comparisonTitle}>Variable Naming:</h4>
+            <p>Choose meaningful variable names! Compare these two equivalent programs:</p>
+            <div className={styles.comparisonGrid}>
+              <div className={styles.goodExample}>
+                <p className={styles.exampleLabel}>Good (Clear)</p>
+                <pre className={styles.codeBlockSmall}>
+                  <code>{`students = ['Fred', 'Ted', 'Ed']
+for student in students:
+    print('Hello', student)`}</code>
+                </pre>
+              </div>
+              <div className={styles.badExample}>
+                <p className={styles.exampleLabel}>Bad (Confusing)</p>
+                <pre className={styles.codeBlockSmall}>
+                  <code>{`xy34q = ['Fred', 'Ted', 'Ed']
+for prz in xy34q:
+    print('Hello', prz)`}</code>
+                </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part4',
+      title: 'Part 4: Working with Multiple Values',
+      description: 'Reassigning variables and preparing for loops',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            Variables can be reassigned to different values. This sets the stage for understanding loops.
+          </p>
+          
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Example: Reassignment</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`student = 'Fred'
+print('Hello', student)
+student = 'Ted'  # Reassign to new value
+print('Hello', student)
+
+# Output:
+# Hello Fred
+# Hello Ted`}</code>
+            </pre>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part5',
+      title: 'Part 5: Introduction to Lists',
+      description: 'Creating and using Python lists',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            Lists are ordered collections of objects in Python. They're written with square brackets and comma-separated items.
+          </p>
+          
+          <div className={styles.conceptBox}>
+            <h4 className={styles.conceptTitle}>List Syntax:</h4>
+            <ul className={styles.conceptList}>
+              <li>Use square brackets: [ ]</li>
+              <li>Separate items with commas</li>
+              <li>Can contain different types: numbers, strings, even other lists</li>
+            </ul>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>List Examples</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`# List of strings
+students = ['Fred', 'Ted', 'Ed']
+
+# List of strings and numbers  
+mixed = ['cat', 'dog']
+
+# List with different types
+complex_list = [5, 'Fred', [7, 19]]`}</code>
+            </pre>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part6',
+      title: 'Part 6: For Loops with Lists',
+      description: 'Iterating through lists with for loops',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            For loops let us repeat actions for each item in a list, eliminating the need to write repetitive code.
+          </p>
+          
+          <div className={styles.conceptBox}>
+            <h4 className={styles.conceptTitle}>For Loop Structure:</h4>
+            <ul className={styles.conceptList}>
+              <li>Starts with <code className={styles.inlineCode}>for</code></li>
+              <li>Variable name to hold each item</li>
+              <li><code className={styles.inlineCode}>in</code> keyword</li>
+              <li>List or collection to iterate over</li>
+              <li>Colon (:) to end the header</li>
+              <li>Indented block of code to repeat</li>
+            </ul>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Basic For Loop</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`for student in ['Fred', 'Ted', 'Ed']:
+    print('Hello', student)
+
+# Output:
+# Hello Fred
+# Hello Ted  
+# Hello Ed`}</code>
+            </pre>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Using a Variable for the List</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`students = ['Fred', 'Ted', 'Ed']
+for student in students:
+    print('Hello', student)`}</code>
+            </pre>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part7',
+      title: 'Part 7: Nested Loops',
+      description: 'Using loops inside other loops',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            When you need to combine items from multiple lists, nested loops provide a powerful solution.
+          </p>
+          
+          <div className={styles.infoBox}>
+            <h4 className={styles.infoTitle}>Understanding Nested Loops:</h4>
+            <p>
+              Read from the bottom up: the inner loop runs completely for each iteration of the outer loop.
+            </p>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Sandwich Combinations Example</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`meats = ['ham', 'pastrami', 'roast beef', 'chicken']
+breads = ['rye', 'whole wheat', 'a roll']
+
+for meat in meats:
+    for bread in breads:
+        print(meat, 'on', bread)
+
+# This creates 12 combinations:
+# ham on rye
+# ham on whole wheat  
+# ham on a roll
+# pastrami on rye
+# pastrami on whole wheat
+# pastrami on a roll
+# ... and so on`}</code>
+            </pre>
+          </div>
+
+          <div className={styles.tipBox}>
+            <h4 className={styles.tipTitle}>Efficiency Tip:</h4>
+            <p>
+              Define lists outside loops when possible. Don't recreate the same list repeatedly inside a loop.
+            </p>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part8',
+      title: 'Part 8: Loops with Strings',
+      description: 'Iterating through characters in strings',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            Strings are ordered collections of characters, so for loops work with them just like with lists.
+          </p>
+          
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Looping Through String Characters</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`vowels = 'aeiou'
+for letter in vowels:
+    print(letter)
+
+# Output:
+# a
+# e  
+# i
+# o
+# u`}</code>
+            </pre>
+          </div>
+
+          <div className={styles.conceptBox}>
+            <h4 className={styles.conceptTitle}>The 'in' Operator:</h4>
+            <p>
+              Use 'in' to check if an item exists in a collection (string, list, etc.)
+            </p>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Checking for Characters</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`if 'a' in 'pineapple':
+    print('found a')    # This prints
+
+if 'b' in 'pineapple':
+    print('found b')    # This doesn't print`}</code>
+            </pre>
+          </div>
+        </div>
+      )
+    },
+    {
+      id: 'part9',
+      title: 'Part 9: Combining Loops and Conditionals',
+      description: 'Using if statements inside for loops',
+      content: (
+        <div className={styles.lessonContent}>
+          <p>
+            Combining for loops with if statements lets you selectively process items based on conditions.
+          </p>
+          
+          <div className={styles.conceptBox}>
+            <h4 className={styles.conceptTitle}>Conditional Processing:</h4>
+            <p>
+              Use if statements inside loops to perform actions only when certain conditions are met.
+            </p>
+          </div>
+
+          <div className={styles.codeExample}>
+            <h4 className={styles.codeTitle}>Finding Vowels in a Word</h4>
+            <pre className={styles.codeBlock}>
+              <code>{`vowels = 'aeiou'
+word = 'pineapple'
+
+for letter in vowels:
+    if letter in word:
+        print(letter, 'is in', word)
+
+# Output:
+# i is in pineapple
+# e is in pineapple
+# a is in pineapple`}</code>
+            </pre>
+          </div>
+
+          <div className={styles.conceptBox}>
+            <h4 className={styles.conceptTitle}>Structure Review:</h4>
+            <ul className={styles.conceptList}>
+              <li><strong>for</strong>: "Do this for each item in the collection"</li>
+              <li><strong>if</strong>: "Do this only when a condition is true"</li>
+              <li>Both end with colons and use indented blocks</li>
+            </ul>
+          </div>
+        </div>
+      )
+    }
+  ];
+
+  const practiceExercises: Exercise[] = [
+    {
+      title: "Exercise 1: Personal Greetings",
+      description: "Create a list of your friends' names and greet each one.",
+      starter: `friends = ['Alice', 'Bob', 'Charlie']
+# Your code here`,
+      solution: `friends = ['Alice', 'Bob', 'Charlie']
+for friend in friends:
+    print('Hello', friend, '!')`
+    },
+    {
+      title: "Exercise 2: Menu Combinations", 
+      description: "Create all possible combinations from two food categories.",
+      starter: `drinks = ['coffee', 'tea', 'juice']
+pastries = ['croissant', 'muffin', 'donut']
+# Your code here`,
+      solution: `drinks = ['coffee', 'tea', 'juice']
+pastries = ['croissant', 'muffin', 'donut']
+
+for drink in drinks:
+    for pastry in pastries:
+        print(drink, 'with', pastry)`
+    },
+    {
+      title: "Exercise 3: Consonant Finder",
+      description: "Find which consonants appear in a given word.",
+      starter: `consonants = 'bcdfghjklmnpqrstvwxyz'
+word = 'programming'
+# Your code here`,
+      solution: `consonants = 'bcdfghjklmnpqrstvwxyz'
+word = 'programming'
+
+for letter in consonants:
+    if letter in word:
+        print(letter, 'is in', word)`
+    }
+  ];
+
+  return (
+    <>
+      <div className={styles.container}>
+        {/* Header */}
+        <div className={styles.header}>
+          <div className={styles.headerContent}>
+            <h1 className={styles.title}>CSCI 133: Computer Programming</h1>
+            <p className={styles.subtitle}>Unit 1: Python Fundamentals</p>
+            <div className={styles.courseMeta}>
+              <span>Hunter College</span>
+              <span>•</span>
+              <span>Fall 2025</span>
+              <span>•</span>
+              <span>9 Parts</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Navigation Tabs */}
+        <div className={styles.navigation}>
+          <div className={styles.navContent}>
+            <nav className={styles.navTabs}>
+              {[
+                { id: 'overview' as const, label: 'Overview', icon: BookOpen },
+                { id: 'lessons' as const, label: 'Lessons', icon: Code },
+                { id: 'practice' as const, label: 'Practice', icon: Play }
+              ].map(({ id, label, icon: Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => setActiveTab(id)}
+                  className={`${styles.navTab} ${activeTab === id ? styles.navTabActive : ''}`}
+                >
+                  <Icon className={styles.navTabIcon} />
+                  <span>{label}</span>
+                </button>
+              ))}
+            </nav>
+          </div>
+        </div>
+
+        <div className={styles.main}>
+          {/* Overview Tab */}
+          {activeTab === 'overview' && (
+            <div className={styles.tabContent}>
+              <div className={styles.overviewSection}>
+                <h2 className={styles.sectionTitle}>Unit Overview</h2>
+                <p className={styles.sectionDescription}>
+                  Welcome to Unit 1 of CSCI 133! This unit introduces you to the fundamental concepts of Python programming. 
+                  You'll learn how to write, save, and run Python programs, work with variables and data types, and use control 
+                  structures like loops and conditionals.
+                </p>
+                
+                <div className={styles.overviewGrid}>
+                  <div className={styles.objectivesCard}>
+                    <h3 className={styles.cardTitle}>Learning Objectives</h3>
+                    <ul className={styles.objectivesList}>
+                      <li>Set up and use the Python IDLE environment</li>
+                      <li>Understand variables, strings, and lists</li>
+                      <li>Write and use for loops effectively</li>
+                      <li>Combine loops with conditional statements</li>
+                    </ul>
+                  </div>
+                  
+                  <div className={styles.prerequisitesCard}>
+                    <h3 className={styles.cardTitle}>Prerequisites</h3>
+                    <ul className={styles.objectivesList}>
+                      <li>Basic computer literacy</li>
+                      <li>No prior programming experience required</li>
+                      <li>Python 3.x installed with IDLE</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
+              <div className={styles.progressSection}>
+                <h3 className={styles.sectionTitle}>Unit Progress</h3>
+                <div className={styles.progressGrid}>
+                  {lessons.map((lesson, index) => (
+                    <div key={lesson.id} className={styles.progressItem}>
+                      <div className={styles.progressNumber}>
+                        {index + 1}
+                      </div>
+                      <div className={styles.progressContent}>
+                        <h4 className={styles.progressTitle}>{lesson.title}</h4>
+                        <p className={styles.progressDescription}>{lesson.description}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Lessons Tab */}
+          {activeTab === 'lessons' && (
+            <div className={styles.tabContent}>
+              <div className={styles.lessonsGrid}>
+                {lessons.map((lesson) => (
+                  <div key={lesson.id} className={styles.lessonCard}>
+                    <button
+                      onClick={() => toggleSection(lesson.id)}
+                      className={styles.lessonHeader}
+                    >
+                      <div className={styles.lessonHeaderContent}>
+                        <h3 className={styles.lessonTitle}>{lesson.title}</h3>
+                        <p className={styles.lessonDescription}>{lesson.description}</p>
+                      </div>
+                      {expandedSections[lesson.id] ? (
+                        <ChevronDown className={styles.chevron} />
+                      ) : (
+                        <ChevronRight className={styles.chevron} />
+                      )}
+                    </button>
+                    
+                    {expandedSections[lesson.id] && (
+                      <div className={styles.lessonBody}>
+                        {lesson.content}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Practice Tab */}
+          {activeTab === 'practice' && (
+            <div className={styles.tabContent}>
+              <div className={styles.practiceIntro}>
+                <h2 className={styles.sectionTitle}>Practice Exercises</h2>
+                <p className={styles.sectionDescription}>
+                  Try these exercises to reinforce what you've learned in Unit 1. Each exercise builds on the concepts 
+                  covered in the lessons.
+                </p>
+              </div>
+
+              <div className={styles.exercisesGrid}>
+                {practiceExercises.map((exercise, index) => (
+                  <div key={index} className={styles.exerciseCard}>
+                    <button
+                      onClick={() => toggleSection(`exercise-${index}`)}
+                      className={styles.exerciseHeader}
+                    >
+                      <div className={styles.exerciseHeaderContent}>
+                        <h3 className={styles.exerciseTitle}>{exercise.title}</h3>
+                        <p className={styles.exerciseDescription}>{exercise.description}</p>
+                      </div>
+                      {expandedSections[`exercise-${index}`] ? (
+                        <ChevronDown className={styles.chevron} />
+                      ) : (
+                        <ChevronRight className={styles.chevron} />
+                      )}
+                    </button>
+                    
+                    {expandedSections[`exercise-${index}`] && (
+                      <div className={styles.exerciseBody}>
+                        <div className={styles.exerciseContent}>
+                          <div className={styles.starterSection}>
+                            <h4 className={styles.starterTitle}>Starter Code:</h4>
+                            <pre className={styles.codeBlock}>
+                              <code>{exercise.starter}</code>
+                            </pre>
+                          </div>
+                          
+                          <details className={styles.solutionDetails}>
+                            <summary className={styles.solutionSummary}>
+                              View Solution
+                            </summary>
+                            <div className={styles.solutionContent}>
+                              <pre className={styles.codeBlock}>
+                                <code>{exercise.solution}</code>
+                              </pre>
+                            </div>
+                          </details>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              <div className={styles.helpSection}>
+                <h3 className={styles.helpTitle}>Need Help?</h3>
+                <p className={styles.helpDescription}>
+                  Remember these key concepts as you work through the exercises:
+                </p>
+                <ul className={styles.helpList}>
+                  <li>Use meaningful variable names</li>
+                  <li>Remember that for loops iterate through each item in a collection</li>
+                  <li>if statements only execute when their condition is True</li>
+                  <li>Indentation is crucial in Python - all code in a block must be aligned</li>
+                  <li>Don't forget the colons (:) after for and if statements</li>
+                </ul>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CSCI133Unit1;

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -15,6 +15,8 @@ import BlogAdminCreate from "./pages/admin/blog/create.tsx";
 import AdminBlogEdit from "./pages/admin/blog/Edit.tsx";
 import AdminProjectIndex from "./pages/admin/projects/index.tsx";
 import AdminProjectEdit from "./pages/admin/projects/edit.tsx";
+import CSCI133Unit1 from "./pages/teaching/csci133/unit1/CSCI133Unit1.tsx";
+import CourseHome from "./pages/teaching/CoursesHome.tsx";
 
 export function AppRoutes() {
   return (
@@ -25,6 +27,8 @@ export function AppRoutes() {
       <Route path="/resume" element={<Resume />} />
       <Route path="/blog" element={<Blog />} />
       <Route path="/contact" element={<Contact />} />
+      <Route path="/teaching" element={<CourseHome />} />
+      <Route path="/teaching/csci133/unit1" element={<CSCI133Unit1 />} />
       <Route path="*" element={<NotFound />} />
       <Route path="/blog/:id" element={<BlogPostPage />} />
       <Route path="/admin/login" element={<AdminLogin />} />


### PR DESCRIPTION
# Add Teaching Section with Course Materials

Added a teaching section for CSCI 133 students with two main pages:

## Changes
- **Courses homepage** (`/courses`) - Landing page with expandable course cards showing available units
- **CSCI 133 Unit 1** (`/hunter/csci133/unit1`) - Interactive Python fundamentals with 9 lessons, code examples, and practice exercises
- **Conditional navbar** - Hidden on course pages for cleaner learning experience
- **Overscroll fix** - Prevents white space when scrolling past page boundaries

## Technical Notes
- Matches existing dark theme with blue/purple gradients
- Fully mobile responsive
- Only shows available units (no "coming soon" placeholders)
- Removed statistics and contact sections to keep it focused